### PR TITLE
Use superclass version of `executescript()`

### DIFF
--- a/synapse/storage/engines/psycopg2.py
+++ b/synapse/storage/engines/psycopg2.py
@@ -83,4 +83,3 @@ class Psycopg2Engine(
         else:
             isolation_level = self.isolation_level_map[isolation_level]
         return conn.set_isolation_level(isolation_level)
-

--- a/synapse/storage/engines/psycopg2.py
+++ b/synapse/storage/engines/psycopg2.py
@@ -84,14 +84,3 @@ class Psycopg2Engine(
             isolation_level = self.isolation_level_map[isolation_level]
         return conn.set_isolation_level(isolation_level)
 
-    @staticmethod
-    def executescript(cursor: psycopg2.extensions.cursor, script: str) -> None:
-        """Execute a chunk of SQL containing multiple semicolon-delimited statements.
-
-        Psycopg2 seems happy to do this in DBAPI2's `execute()` function.
-
-        For consistency with SQLite, any ongoing transaction is committed before
-        executing the script in its own transaction. The script transaction is
-        left open and it is the responsibility of the caller to commit it.
-        """
-        cursor.execute(f"COMMIT; BEGIN TRANSACTION; {script}")


### PR DESCRIPTION
Without this an IndexError from a tuple is raised. Looks like that is because of
`AUTO_INCREMENT_PRIMARY_KEYPLACEHOLDER` contains a `%` which the string formatter
tries to parse and since there is no arg for it to use fails spectacularly